### PR TITLE
Headerコンポーネント新規作成

### DIFF
--- a/app/components/BlogHome.tsx
+++ b/app/components/BlogHome.tsx
@@ -99,7 +99,7 @@ export default function BlogHome() {
       <main className="blog-list">
         {blogs.map((blog) => (
           // ブログ記事クリック時に該当ページに遷移
-          <Link key={blog.id} href={`/blog/${blog.id}`} passHref>
+          <Link key={blog.id} href={`/posts/${blog.id}`} passHref>
             <article className="blog-card">
               <img src={blog.image} alt={blog.title} className="blog-image" />
 

--- a/app/components/BlogMain/BlogMain.module.css
+++ b/app/components/BlogMain/BlogMain.module.css
@@ -19,20 +19,6 @@
   margin: 0;
 }
 
-.userIconButton {
-  border: none;
-  background: none;
-  padding: 0;
-  cursor: pointer;
-}
-
-.userIcon {
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  background-color: #ccc;
-}
-
 .mainImage {
   width: 100%;
   height: 400px;

--- a/app/components/BlogMain/BlogMain.tsx
+++ b/app/components/BlogMain/BlogMain.tsx
@@ -1,27 +1,25 @@
-"use client";
-import Link from "@/node_modules/next/link";
-import React from "react";
 import styles from "./BlogMain.module.css";
 import { Post } from "@/lib/types";
+import UserIconButton from "../UserIconButton/UserIconButton";
+import { useRouter } from "next/navigation";
 
 type Props = {
   post: Post;
 };
 
 const BlogMain: React.FC<Props> = ({ post }) => {
+  const router = useRouter();
+
+  const redirectToUserProfile = () => {
+    router.push(`/user/${post.userName}`);
+  };
+
   return (
     <div className={styles.card}>
       {/* Header */}
       <div className={styles.header}>
         <h1 className={styles.title}>{post.title}</h1>
-        <Link href={`/user/${post.userName}`} className={styles.userIconButton}>
-          <img
-            className={styles.userIcon}
-            src={post.userImagePath}
-            alt=""
-            onError={(e) => (e.currentTarget.src = "/default_icon.jpg")}
-          />
-        </Link>
+        <UserIconButton imagePath={post.userImagePath} onClick={redirectToUserProfile} />
       </div>
 
       {/* Main Image */}

--- a/app/components/Comment/Comment.module.css
+++ b/app/components/Comment/Comment.module.css
@@ -8,26 +8,6 @@
   align-items: center;
 }
 
-.commentUserIcon {
-  width: 50px;
-  height: 50px;
-  border-radius: 50%;
-  overflow: hidden;
-  display: inline-block;
-  cursor: pointer;
-}
-
-.userIcon {
-  width: 100%;
-  height: 100%;
-  background-color: #ccc;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 20px;
-  color: white;
-}
-
 .commentContent {
   flex: 1;
 }

--- a/app/components/Comment/Comment.tsx
+++ b/app/components/Comment/Comment.tsx
@@ -1,8 +1,9 @@
-import Link from "next/link";
 import React from "react";
 import styles from "./Comment.module.css";
 import { BlogComment } from "@/lib/types";
 import calculateTimeAgo from "@/lib/util/calculateTimeAgo";
+import UserIconButton from "../UserIconButton/UserIconButton";
+import { useRouter } from "next/navigation";
 
 type Props = {
   comment: BlogComment;
@@ -10,16 +11,14 @@ type Props = {
 
 const Comment = ({ comment }: Props) => {
   const commentTime = calculateTimeAgo(comment.updatedTime);
+  const router = useRouter();
+
+  const redirectToUserProfile = () => {
+    router.push(`/user/${comment.userName}`);
+  };
   return (
     <div key={comment.id} className={styles.comment}>
-      <Link href={`/user/${comment.userName}`} className={styles.commentUserIcon}>
-        <img
-          src={comment.userImagePath}
-          alt="icon"
-          className={styles.userIcon}
-          aria-label={`Go to ${comment.userName}'s profile`}
-        ></img>
-      </Link>
+      <UserIconButton imagePath={comment.userImagePath} onClick={redirectToUserProfile} />
       <div className={styles.commentContent}>
         <p className={styles.commentText}>{comment.text}</p>
         <span className={styles.commentTime}>{commentTime}</span>

--- a/app/components/Header/Header.module.css
+++ b/app/components/Header/Header.module.css
@@ -39,22 +39,18 @@
   transition: opacity 0.2s;
 }
 
+.navButton.primary {
+  background-color: #333;
+  color: #fff;
+  border: none;
+}
+
+.navButton:hover {
+  opacity: 0.8;
+}
+
 .userSection {
   position: relative;
-}
-
-.userIconButton {
-  border: none;
-  background: none;
-  padding: 0;
-  cursor: pointer;
-}
-
-.userIcon {
-  width: 35px;
-  height: 35px;
-  border-radius: 50%;
-  background-color: #ccc;
 }
 
 .modalBox {
@@ -71,12 +67,17 @@
   gap: 5px;
 }
 
-.navButton.primary {
-  background-color: #333;
-  color: #fff;
-  border: none;
+.modalUserName {
+  text-align: center;
+  font-size: 14px;
 }
 
-.navButton:hover {
-  opacity: 0.8;
+.modalLogoutButton {
+  padding: 3px 15px;
+  font-size: 14px;
+  margin: 0 auto;
+  background-color: #ff31318f;
+  border: none;
+  border-radius: 50px;
+  cursor: pointer;
 }

--- a/app/components/Header/Header.module.css
+++ b/app/components/Header/Header.module.css
@@ -1,0 +1,82 @@
+.header {
+  background-color: #e0e0e0;
+  width: 100%; /* 外枠は画面全体に広げる */
+  height: 70px;
+  align-items: center;
+  display: flex;
+  position: sticky;
+  top: 0;
+}
+
+.inner {
+  display: flex;
+  justify-content: space-between; /* 子要素を左右に配置 */
+  align-items: center; /* 子要素を上下中央に配置 */
+  width: 80%; /* 内側の幅を80%に設定 */
+  max-width: 1200px; /* 最大幅を設定（必要に応じて調整） */
+  margin: 0 auto; /* 中央寄せ */
+}
+
+.logo {
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.nav {
+  display: flex;
+  gap: 15px;
+  align-items: center;
+}
+
+.navButton {
+  background-color: transparent;
+  color: #333;
+  border: 1px solid #333;
+  border-radius: 20px;
+  padding: 5px 15px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.userSection {
+  position: relative;
+}
+
+.userIconButton {
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.userIcon {
+  width: 35px;
+  height: 35px;
+  border-radius: 50%;
+  background-color: #ccc;
+}
+
+.modalBox {
+  position: absolute;
+  padding: 10px 0px;
+  top: 54px;
+  background-color: #b3b3b3;
+  border-radius: 8px;
+  width: 100px;
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  align-items: center; /* 子要素を左右中央に配置 */
+  gap: 5px;
+}
+
+.navButton.primary {
+  background-color: #333;
+  color: #fff;
+  border: none;
+}
+
+.navButton:hover {
+  opacity: 0.8;
+}

--- a/app/components/Header/Header.tsx
+++ b/app/components/Header/Header.tsx
@@ -4,6 +4,7 @@ import styles from "./Header.module.css";
 import Link from "next/link"; // Linkコンポーネントをインポート
 import EditIcon from "@mui/icons-material/Edit";
 import { User } from "@/lib/types";
+import UserIconButton from "../UserIconButton/UserIconButton";
 
 // ダミーデータ
 const user: User = {
@@ -64,36 +65,14 @@ export const Header = () => {
           )}
           {signedInUser && (
             <div className={styles.userSection}>
-              <button onClick={() => setIsOpen(!isOpen)} className={styles.userIconButton}>
-                <img
-                  className={styles.userIcon}
-                  src={signedInUser.imagePath}
-                  alt=""
-                  onError={(e) => (e.currentTarget.src = "/default_icon.jpg")}
-                />
-              </button>
+              <UserIconButton imagePath={user.imagePath} onClick={() => setIsOpen(!isOpen)} />
               {isOpen && (
                 <div className={styles.modalBox} ref={modalRef}>
-                  <p
-                    style={{
-                      textAlign: "center",
-                      fontSize: "14px",
-                    }}
-                  >
-                    {signedInUser?.name}
-                  </p>
+                  <p className={styles.modalUserName}>{signedInUser?.name}</p>
                   <button
                     // 本来はSignedOutApi呼び出しなどを行う。
                     onClick={() => setSignedInUser(null)}
-                    style={{
-                      padding: "3px 15px",
-                      fontSize: "14px",
-                      margin: " 0 auto",
-                      backgroundColor: "#FF31318F",
-                      border: "none",
-                      borderRadius: "50px",
-                      cursor: "pointer",
-                    }}
+                    className={styles.modalLogoutButton}
                   >
                     Logout
                   </button>

--- a/app/components/Header/Header.tsx
+++ b/app/components/Header/Header.tsx
@@ -1,0 +1,108 @@
+"use client";
+import React, { useEffect, useRef, useState } from "react";
+import styles from "./Header.module.css";
+import Link from "next/link"; // Linkコンポーネントをインポート
+import EditIcon from "@mui/icons-material/Edit";
+import { User } from "@/lib/types";
+
+// ダミーデータ
+const user: User = {
+  id: 0,
+  name: "テスト太郎",
+  email: "testtarou@gmail.com",
+  imagePath: "/testtarou.jpg",
+};
+//ダミーデータ終了
+
+export const Header = () => {
+  // 本来はSessionか何かから、User情報の取得を行う。
+  const [signedInUser, setSignedInUser] = useState<User | null>(user);
+
+  // モーダルの開閉状態を管理
+  const [isOpen, setIsOpen] = useState(false);
+
+  // モーダルのDOM要素への参照を保持
+  const modalRef = useRef<HTMLDivElement | null>(null);
+
+  // モーダル外クリック時にモーダルを閉じる処理
+  const handleClickOutside = (event: MouseEvent) => {
+    if (modalRef.current && !modalRef.current.contains(event.target as Node)) {
+      setIsOpen(false);
+    }
+  };
+
+  // モーダルが開いている間だけ、クリックイベントを監視してモーダル外クリックを検知
+  useEffect(() => {
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+    } else {
+      document.removeEventListener("mousedown", handleClickOutside);
+    }
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isOpen]);
+
+  return (
+    <header className={styles.header}>
+      <div className={styles.inner}>
+        <div className={styles.logo}>LOGO</div>
+        <nav className={styles.nav}>
+          <Link href="/" passHref>
+            <button className={`${styles.navButton} ${styles.primary}`}>Home</button>
+          </Link>
+          <Link href="/post/create" passHref>
+            <button className={`${styles.navButton} ${styles.primary}`}>
+              <EditIcon sx={{ fontSize: 10, marginRight: 1 }}></EditIcon>
+              Create
+            </button>
+          </Link>
+          {!signedInUser && (
+            <Link href="/signin" passHref>
+              <button className={styles.navButton}>Sign In</button>
+            </Link>
+          )}
+          {signedInUser && (
+            <div className={styles.userSection}>
+              <button onClick={() => setIsOpen(!isOpen)} className={styles.userIconButton}>
+                <img
+                  className={styles.userIcon}
+                  src={signedInUser.imagePath}
+                  alt=""
+                  onError={(e) => (e.currentTarget.src = "/default_icon.jpg")}
+                />
+              </button>
+              {isOpen && (
+                <div className={styles.modalBox} ref={modalRef}>
+                  <p
+                    style={{
+                      textAlign: "center",
+                      fontSize: "14px",
+                    }}
+                  >
+                    {signedInUser?.name}
+                  </p>
+                  <button
+                    // 本来はSignedOutApi呼び出しなどを行う。
+                    onClick={() => setSignedInUser(null)}
+                    style={{
+                      padding: "3px 15px",
+                      fontSize: "14px",
+                      margin: " 0 auto",
+                      backgroundColor: "#FF31318F",
+                      border: "none",
+                      borderRadius: "50px",
+                      cursor: "pointer",
+                    }}
+                  >
+                    Logout
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+        </nav>
+      </div>
+    </header>
+  );
+};

--- a/app/components/UserIconButton/UserIconButton.module.css
+++ b/app/components/UserIconButton/UserIconButton.module.css
@@ -1,0 +1,13 @@
+.userIconButton {
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.userIcon {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background-color: #ccc;
+}

--- a/app/components/UserIconButton/UserIconButton.tsx
+++ b/app/components/UserIconButton/UserIconButton.tsx
@@ -1,0 +1,27 @@
+"use client";
+import { useState } from "react";
+import styles from "./UserIconButton.module.css";
+
+interface UserIconButtonProps {
+  imagePath: string;
+  onClick: () => void;
+  className?: string;
+}
+
+const UserIconButton: React.FC<UserIconButtonProps> = ({ imagePath, onClick }) => {
+  const [imageLoaded, setImageLoaded] = useState(false);
+
+  return (
+    <button onClick={onClick} className={styles.userIconButton}>
+      <img
+        className={styles.userIcon}
+        src={imageLoaded ? imagePath : "/default_icon.jpg"}
+        alt="user icon image"
+        onLoad={() => setImageLoaded(true)}
+        onError={() => setImageLoaded(false)}
+      />
+    </button>
+  );
+};
+
+export default UserIconButton;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
+import { Header } from "./components/Header/Header";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -16,7 +17,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja">
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        <Header />
+        {children}
+      </body>
     </html>
   );
 }

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -1,3 +1,4 @@
 export * from "./blogComment";
 export * from "./post";
 export * from "./thumbnail";
+export * from "./user";

--- a/lib/types/user.d.ts
+++ b/lib/types/user.d.ts
@@ -1,0 +1,6 @@
+export interface User {
+  id: number;
+  name: string;
+  email: string;
+  imagePath: string;
+}


### PR DESCRIPTION
close #9

## やったこと・変更内容（ビューの変更がある場合はスクショによる比較などがあるとわかりやすい ）

- ヘッダーコンポーネントの新規作成。
- User型の追加。
- layout.tsxがヘッダーコンポーネントを参照するように変更。

## レビュー観点（レビューをする際に見てほしい点など）

- Profile画像押下時、user名とlogoutボタン押下するモーダルの表示を行っているのですがそちらの、実装方法はあっておりますか。またcssの適応も曖昧な気がしました。
-  Userのアイコンの画像を表示する箇所を共通化しました。
- BlogHomeコンポーネントのブログ詳細記事へのリンクがまちがっておりました。報告だけのつもりでしたが間違えて、pushしてしまいました。
誤：/blog/${blog.id}
正：/posts/${blog.id}
