### PR TITLE
記事削除用Apiの新規作成

### DIFF
--- a/app/api/posts/delete/route.ts
+++ b/app/api/posts/delete/route.ts
@@ -1,0 +1,21 @@
+import { supabase } from "lib/util/supabase";
+import { NextResponse } from "next/server";
+
+// DELETEリクエストを処理
+export async function POST(req: Request) {
+  try {
+    const { id } = await req.json(); // リクエストボディからIDを取得
+    if (!id) {
+      return NextResponse.json({ error: "ID is required" }, { status: 400 });
+    }
+
+    const { error } = await supabase.from("posts").delete().eq("id", id);
+    if (error) {
+      throw error;
+    }
+
+    return NextResponse.json({ message: `Post with ID ${id} deleted successfully` });
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}


### PR DESCRIPTION
close #32

## やったこと・変更内容（ビューの変更がある場合はスクショによる比較などがあるとわかりやすい ）

- 記事削除用Apiの新規作成。記事のidを受け取り、該当の記事の削除を行う。

## レビュー観点（レビューをする際に見てほしい点など）

- フロントエンドの呼び出し部分が未実装のため、apiの作成だけを行いました。